### PR TITLE
Fix Gradio Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ https://github.com/user-attachments/assets/3212a800-406f-4d79-8aa1-d814eed815d6
 pip install -U israwave
 ```
 
+Some dependencies are only available on MacOSX and windows in python version 3.12.
 You also need [`israwave.onnx`](https://github.com/thewh1teagle/israwave/releases/download/v0.1.0/israwave.onnx), [`espeak-ng-data`](https://github.com/thewh1teagle/israwave/releases/download/v0.1.0/espeak-ng-data.tar.gz), and [`nakdimon.onnx`](https://github.com/thewh1teagle/israwave/releases/download/v0.1.0/nakdimon.onnx). Please see examples.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ https://github.com/user-attachments/assets/3212a800-406f-4d79-8aa1-d814eed815d6
 pip install -U israwave
 ```
 
-Some dependencies are only available on MacOSX and windows in python version 3.12.
+Some dependencies are only available in python version 3.12.
+
 You also need [`israwave.onnx`](https://github.com/thewh1teagle/israwave/releases/download/v0.1.0/israwave.onnx), [`espeak-ng-data`](https://github.com/thewh1teagle/israwave/releases/download/v0.1.0/espeak-ng-data.tar.gz), and [`nakdimon.onnx`](https://github.com/thewh1teagle/israwave/releases/download/v0.1.0/nakdimon.onnx). Please see examples.
 
 ## Examples

--- a/israwave/helpers.py
+++ b/israwave/helpers.py
@@ -1,5 +1,29 @@
+import numpy as np
+import soundfile as sf
+import io
+
 def text_has_niqqud(text: str) -> bool:
     return any("\u0591" <= char <= "\u05C7" for char in text)
 
 def text_has_ipa(text: str) -> bool:
     return any("\u0250" <= char <= "\u02AF" for char in text)
+
+def float_to_int16(samples: np.floating) -> np.int16:
+    """
+    Normalize audio_array if it's floating-point
+    """
+    if np.issubdtype(samples.dtype, np.floating):
+        max_val = np.max(np.abs(samples))
+        samples = (samples / max_val) * 32767 # Normalize to 16-bit range
+        samples = samples.astype(np.int16)
+    return samples
+
+def to_ogg(samples: np.array, sample_rate: int):
+    # Normalize audio_array if it's floating-point
+    samples = float_to_int16(samples)
+    # Create in memory buffer of ogg
+    buf = io.BytesIO()
+    buf.name = 'audio.ogg'
+    sf.write(buf, samples, sample_rate, format="ogg")
+    buf.seek(0)
+    return buf

--- a/ui/app.py
+++ b/ui/app.py
@@ -10,7 +10,7 @@ python3 app.py
 
 import gradio as gr
 from israwave import IsraWave
-from israwave.helpers import text_has_niqqud
+from israwave.helpers import text_has_niqqud, float_to_int16
 from nakdimon_ort import Nakdimon
 from israwave.segment import SegmentExtractor
 import numpy as np
@@ -29,7 +29,10 @@ def create(text: str, rate, pitch, energy):
         waveforms.append(waveform.samples)
         silence = segment.create_pause(waveform.sample_rate)
         waveforms.append(silence)
-    return speech_model.sample_rate, np.concatenate(waveforms)
+    waveform = np.concatenate(waveforms)
+    # Gradio expect int16
+    waveform = float_to_int16(waveform)
+    return speech_model.sample_rate, waveform
 
 
 with gr.Blocks(theme=gr.themes.Soft()) as demo:

--- a/ui/app.py
+++ b/ui/app.py
@@ -14,6 +14,34 @@ from israwave.helpers import text_has_niqqud
 from nakdimon_ort import Nakdimon
 from israwave.segment import SegmentExtractor
 import numpy as np
+from pydub import AudioSegment
+import io
+
+
+def numpy_to_mp3(audio_array, sampling_rate):
+    # Normalize audio_array if it's floating-point
+    if np.issubdtype(audio_array.dtype, np.floating):
+        max_val = np.max(np.abs(audio_array))
+        audio_array = (audio_array / max_val) * 32767 # Normalize to 16-bit range
+        audio_array = audio_array.astype(np.int16)
+
+    # Create an audio segment from the numpy array
+    audio_segment = AudioSegment(
+        audio_array.tobytes(),
+        frame_rate=sampling_rate,
+        sample_width=audio_array.dtype.itemsize,
+        channels=1
+    )
+
+    # Export the audio segment to MP3 bytes - use a high bitrate to maximise quality
+    mp3_io = io.BytesIO()
+    audio_segment.export(mp3_io, format="mp3", bitrate="320k")
+
+    # Get the MP3 bytes
+    mp3_bytes = mp3_io.getvalue()
+    mp3_io.close()
+
+    return mp3_bytes
 
 segment_extractor = SegmentExtractor()
 speech_model = IsraWave('israwave.onnx', 'espeak-ng-data')
@@ -22,17 +50,15 @@ niqqud_model = Nakdimon('nakdimon.onnx')
 def create_audio(text: str, rate, pitch, energy):
     if not text_has_niqqud(text):
         text = niqqud_model.compute(text)
-    waveforms = []
     for segment in segment_extractor.extract_segments(text):
         waveform = speech_model.create(segment.text, rate=rate, pitch=pitch, energy=energy)
-        waveforms.append(waveform.samples)
         silence = segment.create_pause(waveform.sample_rate)
-        waveforms.append(silence)
-    return np.concatenate(waveforms), speech_model.sample_rate
+        audio = np.concatenate([waveform.samples, silence])
+        waveform_bytes = numpy_to_mp3(audio, waveform.sample_rate)
+        yield waveform_bytes
 
 def create(text, rate, pitch, energy):
-    samples, sample_rate = create_audio(text, rate, pitch, energy)
-    return (sample_rate, samples)
+    yield from create_audio(text, rate, pitch, energy)
 
 
 with gr.Blocks(theme=gr.themes.Soft()) as demo:
@@ -49,7 +75,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
     energy = gr.Slider(0.1, 10, label="energy", value=1.0)
 
     button = gr.Button("Create", elem_id="create_button")
-    output = gr.Audio()
+    output = gr.Audio(streaming=True, autoplay=True)
     
     button.click(fn=create, inputs=[text, rate, pitch, energy], outputs=output)
 

--- a/ui/app.py
+++ b/ui/app.py
@@ -14,51 +14,30 @@ from israwave.helpers import text_has_niqqud
 from nakdimon_ort import Nakdimon
 from israwave.segment import SegmentExtractor
 import numpy as np
-from pydub import AudioSegment
-import io
-
-
-def numpy_to_mp3(audio_array, sampling_rate):
-    # Normalize audio_array if it's floating-point
-    if np.issubdtype(audio_array.dtype, np.floating):
-        max_val = np.max(np.abs(audio_array))
-        audio_array = (audio_array / max_val) * 32767 # Normalize to 16-bit range
-        audio_array = audio_array.astype(np.int16)
-
-    # Create an audio segment from the numpy array
-    audio_segment = AudioSegment(
-        audio_array.tobytes(),
-        frame_rate=sampling_rate,
-        sample_width=audio_array.dtype.itemsize,
-        channels=1
-    )
-
-    # Export the audio segment to MP3 bytes - use a high bitrate to maximise quality
-    mp3_io = io.BytesIO()
-    audio_segment.export(mp3_io, format="mp3", bitrate="320k")
-
-    # Get the MP3 bytes
-    mp3_bytes = mp3_io.getvalue()
-    mp3_io.close()
-
-    return mp3_bytes
+import soundfile as sf
+import tempfile
 
 segment_extractor = SegmentExtractor()
-speech_model = IsraWave('israwave.onnx', 'espeak-ng-data')
-niqqud_model = Nakdimon('nakdimon.onnx')
+speech_model = IsraWave("israwave.onnx", "espeak-ng-data")
+niqqud_model = Nakdimon("nakdimon.onnx")
 
-def create_audio(text: str, rate, pitch, energy):
+
+def create(text: str, rate, pitch, energy):
     if not text_has_niqqud(text):
         text = niqqud_model.compute(text)
+    waveforms = []
     for segment in segment_extractor.extract_segments(text):
-        waveform = speech_model.create(segment.text, rate=rate, pitch=pitch, energy=energy)
+        waveform = speech_model.create(
+            segment.text, rate=rate, pitch=pitch, energy=energy
+        )
+        waveforms.append(waveform.samples)
         silence = segment.create_pause(waveform.sample_rate)
-        audio = np.concatenate([waveform.samples, silence])
-        waveform_bytes = numpy_to_mp3(audio, waveform.sample_rate)
-        yield waveform_bytes
+        waveforms.append(silence)
+    waveform = np.concatenate(waveforms)
 
-def create(text, rate, pitch, energy):
-    yield from create_audio(text, rate, pitch, energy)
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".ogg") as temp_file:
+        sf.write(temp_file.name, waveform, speech_model.sample_rate, format="ogg")
+        return temp_file.name
 
 
 with gr.Blocks(theme=gr.themes.Soft()) as demo:
@@ -67,16 +46,21 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
     <h1 style='text-align: center;'>IsraWave</h1>
     <p style='text-align: center;'>Text-to-Speech model for Hebrew</p>
     """)
-    
+
     # Use Textarea with RTL direction
-    text = gr.TextArea(label="text", lines=4, elem_id="rtl_textarea", value='זה כיף להזמין דברים באינטרנט, אבל הרבה פחות כיף לחכות ולחכות עד שהם יגיעו אלינו. אז מה בעצם עובר על החבילות בדרך הארוכה עד לבית שלנו? והאם אפשר לגרום לכך שהן יגיעו מהר יותר? ')
+    text = gr.TextArea(
+        label="text",
+        lines=4,
+        elem_id="rtl_textarea",
+        value="זה כיף להזמין דברים באינטרנט, אבל הרבה פחות כיף לחכות ולחכות עד שהם יגיעו אלינו. אז מה בעצם עובר על החבילות בדרך הארוכה עד לבית שלנו? והאם אפשר לגרום לכך שהן יגיעו מהר יותר? ",
+    )
     rate = gr.Slider(0.1, 10, label="rate", value=1.0)
     pitch = gr.Slider(0.1, 10, label="pitch", value=1.0)
     energy = gr.Slider(0.1, 10, label="energy", value=1.0)
 
     button = gr.Button("Create", elem_id="create_button")
-    output = gr.Audio(streaming=True, autoplay=True)
-    
+    output = gr.Audio(autoplay=True)
+
     button.click(fn=create, inputs=[text, rate, pitch, energy], outputs=output)
 
     # Custom CSS for RTL direction
@@ -86,7 +70,7 @@ with gr.Blocks(theme=gr.themes.Soft()) as demo:
         font-size: 20px;
     }
     """
-    
+
     gr.Markdown("""
     <p style='text-align: center;'><a href='https://github.com/thewh1teagle/israwave' target='_blank'>Israwave on Github</a></p>
     """)

--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,2 +1,5 @@
-gradio
+# pre-release version of gradio 5.0 (better streaming support)
+gradio==5.0.0b1
 israwave
+# backwards compatibility bug in fastapi fixed in next gradio version
+fastapi==0.112.4

--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,5 +1,2 @@
-# pre-release version of gradio 5.0 (better streaming support)
-gradio==5.0.0b1
+gradio
 israwave
-# backwards compatibility bug in fastapi fixed in next gradio version
-fastapi==0.112.4


### PR DESCRIPTION
When streaming audio, the data must be either in bytes or a file not a tuple. 

I think this is something we can fix in core gradio. 

Also updated the demo to use the Gradio 5.0 pre-release. No breaking changes compared to Gradio 4 for this demo but under-the-hood Gradio 5 is a lot better for streaming media. Official release in about 2 weeks.

BTW this model is incredible. It's so fast. Can you share the steps to train such a model and make it so fast? Would be great for the community. 

https://github.com/user-attachments/assets/6b2d9a9a-82ca-4517-bd9d-ae86e80ef831


